### PR TITLE
Fix #15: Update setup to include all files in wheel

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include README.md
-recursive-include django-presskit/static *
-recursive-include django-presskit/templates *
+recursive-include django_presskit/static *
+recursive-include django_presskit/templates *

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="django_presskit",
-    version="1.1.1",
+    version="1.1.2",
     author="Future Proof Games",
     author_email="info@futureproofgames.com",
     description="A port of presskit() to Django",
@@ -13,6 +13,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/FutureProofGames/django-presskit.git",
     packages=setuptools.find_packages(),
+    include_package_data=True,
     classifiers=[
         "Programming Language :: Python :: 2.7",
         "Framework :: Django :: 1.11",

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setuptools.setup(
     classifiers=[
         "Programming Language :: Python :: 2.7",
         "Framework :: Django :: 1.11",
-        "License :: OSI Approved :: MIT License",
+        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
         "Operating System :: OS Independent",
     ],
 )


### PR DESCRIPTION
The wheel creation process requires an additional field in `setup.py` for it to leverage `MANIFEST.in`. This is hotfixing to master, and will bump the patch version.